### PR TITLE
Update use effect to reset the store if user is not authenticated

### DIFF
--- a/components/AuthNav.tsx
+++ b/components/AuthNav.tsx
@@ -22,9 +22,7 @@ export default function AuthNavigation() {
   // If the store is empty, fetch the pioneer data from the access token
   useEffect(() => {
     if (!isAuthenticated) {
-      setName('')
-      setAvatar('')
-      setColor('')
+      resetStore()
       return
     }
 

--- a/components/AuthNav.tsx
+++ b/components/AuthNav.tsx
@@ -21,7 +21,12 @@ export default function AuthNavigation() {
 
   // If the store is empty, fetch the pioneer data from the access token
   useEffect(() => {
-    if (!isAuthenticated) return
+    if (!isAuthenticated) {
+      setName('')
+      setAvatar('')
+      setColor('')
+      return
+    }
 
     if ((!name || !avatar || !color)) {
       const accessToken = getAccessToken()


### PR DESCRIPTION
When user's are logged out passively, becuase of the tokes are expired, the auth nav looks like the user is still authenticated.
That happens because of pioneer store is not being updated when user logs out passively.

To fix this, we'll reset the pioneer store when the user is not authenticated.